### PR TITLE
feat: ignore values for specific keys

### DIFF
--- a/src/cssToTailwind.ts
+++ b/src/cssToTailwind.ts
@@ -10,6 +10,10 @@ export const cssToTailwind = async (cssObj: Record<string, string>, ignoreFields
 		for (const field of ignoreFields) {
 			if (field.includes('=')) {
 				const [key, value] = field.split('=');
+				if (value === '*' && cssObj[key]) {
+					delete cssObj[key];
+				}
+
 				if (cssObj[key] === value) {
 					delete cssObj[key];
 				}


### PR DESCRIPTION
This PR adds support for the `key=*` syntax where the `key` is a css property that you would like the value of to always be ignored for.

**Status and versioning classification:**

<!--
Please move lines that apply to you out of the comment:
- Code changes have been tested and working fine, or there are no code changes
- This PR changes the library's interface (methods or parameters added)
- This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- This PR **only** includes non-code changes, like changes to documentation, README, etc.
-->
